### PR TITLE
Removed minSize dimension from data matrix writer.

### DIFF
--- a/ZXingObjC/datamatrix/ZXDataMatrixWriter.m
+++ b/ZXingObjC/datamatrix/ZXDataMatrixWriter.m
@@ -46,7 +46,7 @@
 
   // Try to get force shape & min / max size
   ZXDataMatrixSymbolShapeHint shape = ZXDataMatrixSymbolShapeHintForceNone;
-  ZXDimension *minSize = [[ZXDimension alloc] initWithWidth:width height:height];
+  ZXDimension *minSize = nil;
   ZXDimension *maxSize = nil;
   if (hints != nil) {
     shape = hints.dataMatrixShape;


### PR DESCRIPTION
Calling `[writer encode:string format:kBarcodeFormatDataMatrix width:size.width height:size.height error:&error]` would raise an `NSInvalidArgumentException` - "Can't find a symbol arrangement that matches the message. Data codewords: 5".

This is the same bug as identified [here](https://github.com/zxing/zxing/issues/361) so same fix was applied.
