### PR TITLE
Set bitsPerComponent 8 instead of CGImageGetBitsPerComponent

### DIFF
--- a/ZXingObjC/client/ZXCGImageLuminanceSource.m
+++ b/ZXingObjC/client/ZXCGImageLuminanceSource.m
@@ -271,7 +271,7 @@
   CGContextRef context = CGBitmapContextCreate(NULL,
                                                rotatedRect.size.width,
                                                rotatedRect.size.height,
-                                               CGImageGetBitsPerComponent(self.image),
+                                               8,
                                                0,
                                                colorSpace,
                                                kCGBitmapAlphaInfoMask & kCGImageAlphaPremultipliedFirst);


### PR DESCRIPTION
Specified 8 as bitsPerComponent because the new image's color space is CGColorSpaceCreateDeviceRGB()

Without this, it fails to create CGContextRef when CGImageGetBitsPerComponent(self.image) has less value than 8.