### PR TITLE
Enable independent use of subspecs

### DIFF
--- a/ZXingObjC.podspec
+++ b/ZXingObjC.podspec
@@ -21,32 +21,43 @@ Pod::Spec.new do |s|
     ss.source_files = 'ZXingObjC/**/*.{h,m}'
   end
 
+  s.subspec 'Core' do |ss|
+    ss.source_files = 'ZXingObjC/*.{h,m}', 'ZXingObjC/client/*.{h,m}', 'ZXingObjC/common/**/*.{h,m}', 'ZXingObjC/core/**/*.{h,m}', 'ZXingObjC/multi/**/*.{h,m}'
+  end
+
   s.subspec 'Aztec' do |ss|
     ss.dependency 'ZXingObjC/Core'
     ss.source_files = 'ZXingObjC/aztec/**/*.{h,m}'
-  end
-
-  s.subspec 'Core' do |ss|
-    ss.source_files = 'ZXingObjC/client/*.{h,m}', 'ZXingObjC/common/**/*.{h,m}', 'ZXingObjC/core/*.{h,m}', 'ZXingObjC/multi/*.{h,m}'
+    ss.xcconfig = { "GCC_PREPROCESSOR_DEFINITIONS" => "ZXINGOBJC_USE_SUBSPECS ZXINGOBJC_AZTEC" }
   end
 
   s.subspec 'DataMatrix' do |ss|
     ss.dependency 'ZXingObjC/Core'
     ss.source_files = 'ZXingObjC/datamatrix/**/*.{h,m}'
+    ss.xcconfig = { "GCC_PREPROCESSOR_DEFINITIONS" => "ZXINGOBJC_USE_SUBSPECS ZXINGOBJC_DATAMATRIX" }
   end
 
   s.subspec 'MaxiCode' do |ss|
     ss.dependency 'ZXingObjC/Core'
     ss.source_files = 'ZXingObjC/maxicode/**/*.{h,m}'
+    ss.xcconfig = { "GCC_PREPROCESSOR_DEFINITIONS" => "ZXINGOBJC_USE_SUBSPECS ZXINGOBJC_MAXICODE" }
   end
 
   s.subspec 'OneD' do |ss|
     ss.dependency 'ZXingObjC/Core'
-    ss.source_files = 'ZXingObjC/oned/**/*.{h,m}', 'ZXingObjC/client/result/*.{h,m}'
+    ss.source_files = 'ZXingObjC/oned/**/*.{h,m}', 'ZXingObjC/client/result/**/*.{h,m}'
+    ss.xcconfig = { "GCC_PREPROCESSOR_DEFINITIONS" => "ZXINGOBJC_USE_SUBSPECS ZXINGOBJC_ONED" }
+  end
+
+  s.subspec 'PDF417' do |ss|
+    ss.dependency 'ZXingObjC/Core'
+    ss.source_files = 'ZXingObjC/pdf417/**/*.{h,m}'
+    ss.xcconfig = { "GCC_PREPROCESSOR_DEFINITIONS" => "ZXINGOBJC_USE_SUBSPECS ZXINGOBJC_PDF417" }
   end
 
   s.subspec 'QRCode' do |ss|
     ss.dependency 'ZXingObjC/Core'
     ss.source_files = 'ZXingObjC/qrcode/**/*.{h,m}'
+    ss.xcconfig = { "GCC_PREPROCESSOR_DEFINITIONS" => "ZXINGOBJC_USE_SUBSPECS ZXINGOBJC_QRCODE" }
   end
 end

--- a/ZXingObjC/ZXMultiFormatReader.m
+++ b/ZXingObjC/ZXMultiFormatReader.m
@@ -14,17 +14,30 @@
  * limitations under the License.
  */
 
-#import "ZXAztecReader.h"
 #import "ZXBinaryBitmap.h"
-#import "ZXDataMatrixReader.h"
 #import "ZXDecodeHints.h"
 #import "ZXErrors.h"
-#import "ZXMaxiCodeReader.h"
-#import "ZXMultiFormatOneDReader.h"
 #import "ZXMultiFormatReader.h"
-#import "ZXPDF417Reader.h"
-#import "ZXQRCodeReader.h"
 #import "ZXResult.h"
+
+#if defined(ZXINGOBJC_AZTEC) || !defined(ZXINGOBJC_USE_SUBSPECS)
+#import "ZXAztecReader.h"
+#endif
+#if defined(ZXINGOBJC_DATAMATRIX) || !defined(ZXINGOBJC_USE_SUBSPECS)
+#import "ZXDataMatrixReader.h"
+#endif
+#if defined(ZXINGOBJC_MAXICODE) || !defined(ZXINGOBJC_USE_SUBSPECS)
+#import "ZXMaxiCodeReader.h"
+#endif
+#if defined(ZXINGOBJC_ONED) || !defined(ZXINGOBJC_USE_SUBSPECS)
+#import "ZXMultiFormatOneDReader.h"
+#endif
+#if defined(ZXINGOBJC_PDF417) || !defined(ZXINGOBJC_USE_SUBSPECS)
+#import "ZXPDF417Reader.h"
+#endif
+#if defined(ZXINGOBJC_QRCODE) || !defined(ZXINGOBJC_USE_SUBSPECS)
+#import "ZXQRCodeReader.h"
+#endif
 
 @interface ZXMultiFormatReader ()
 
@@ -103,38 +116,66 @@
       [hints containsFormat:kBarcodeFormatRSS14] ||
       [hints containsFormat:kBarcodeFormatRSSExpanded];
     if (addZXOneDReader && !tryHarder) {
+#if defined(ZXINGOBJC_ONED) || !defined(ZXINGOBJC_USE_SUBSPECS)
       [self.readers addObject:[[ZXMultiFormatOneDReader alloc] initWithHints:hints]];
+#endif
     }
+#if defined(ZXINGOBJC_QRCODE) || !defined(ZXINGOBJC_USE_SUBSPECS)
     if ([hints containsFormat:kBarcodeFormatQRCode]) {
       [self.readers addObject:[[ZXQRCodeReader alloc] init]];
     }
+#endif
+#if defined(ZXINGOBJC_DATAMATRIX) || !defined(ZXINGOBJC_USE_SUBSPECS)
     if ([hints containsFormat:kBarcodeFormatDataMatrix]) {
       [self.readers addObject:[[ZXDataMatrixReader alloc] init]];
     }
+#endif
+#if defined(ZXINGOBJC_AZTEC) || !defined(ZXINGOBJC_USE_SUBSPECS)
     if ([hints containsFormat:kBarcodeFormatAztec]) {
       [self.readers addObject:[[ZXAztecReader alloc] init]];
     }
+#endif
+#if defined(ZXINGOBJC_PDF417) || !defined(ZXINGOBJC_USE_SUBSPECS)
     if ([hints containsFormat:kBarcodeFormatPDF417]) {
       [self.readers addObject:[[ZXPDF417Reader alloc] init]];
     }
+#endif
+#if defined(ZXINGOBJC_MAXICODE) || !defined(ZXINGOBJC_USE_SUBSPECS)
     if ([hints containsFormat:kBarcodeFormatMaxiCode]) {
       [self.readers addObject:[[ZXMaxiCodeReader alloc] init]];
     }
+#endif
+#if defined(ZXINGOBJC_ONED) || !defined(ZXINGOBJC_USE_SUBSPECS)
     if (addZXOneDReader && tryHarder) {
       [self.readers addObject:[[ZXMultiFormatOneDReader alloc] initWithHints:hints]];
     }
+#endif
   }
   if ([self.readers count] == 0) {
     if (!tryHarder) {
+#if defined(ZXINGOBJC_ONED) || !defined(ZXINGOBJC_USE_SUBSPECS)
       [self.readers addObject:[[ZXMultiFormatOneDReader alloc] initWithHints:hints]];
+#endif
     }
+#if defined(ZXINGOBJC_QRCODE) || !defined(ZXINGOBJC_USE_SUBSPECS)
     [self.readers addObject:[[ZXQRCodeReader alloc] init]];
+#endif
+#if defined(ZXINGOBJC_DATAMATRIX) || !defined(ZXINGOBJC_USE_SUBSPECS)
     [self.readers addObject:[[ZXDataMatrixReader alloc] init]];
+#endif
+#if defined(ZXINGOBJC_AZTEC) || !defined(ZXINGOBJC_USE_SUBSPECS)
     [self.readers addObject:[[ZXAztecReader alloc] init]];
+#endif
+#if defined(ZXINGOBJC_PDF417) || !defined(ZXINGOBJC_USE_SUBSPECS)
     [self.readers addObject:[[ZXPDF417Reader alloc] init]];
+#endif
+#if defined(ZXINGOBJC_MAXICODE) || !defined(ZXINGOBJC_USE_SUBSPECS)
     [self.readers addObject:[[ZXMaxiCodeReader alloc] init]];
+#endif
     if (tryHarder) {
+#if defined(ZXINGOBJC_ONED) || !defined(ZXINGOBJC_USE_SUBSPECS)
       [self.readers addObject:[[ZXMultiFormatOneDReader alloc] initWithHints:hints]];
+#endif
     }
   }
 }

--- a/ZXingObjC/ZXMultiFormatWriter.m
+++ b/ZXingObjC/ZXMultiFormatWriter.m
@@ -14,20 +14,31 @@
  * limitations under the License.
  */
 
-#import "ZXAztecWriter.h"
 #import "ZXBitMatrix.h"
+#import "ZXErrors.h"
+#import "ZXMultiFormatWriter.h"
+
+#if defined(ZXINGOBJC_AZTEC) || !defined(ZXINGOBJC_USE_SUBSPECS)
+#import "ZXAztecWriter.h"
+#endif
+#if defined(ZXINGOBJC_ONED) || !defined(ZXINGOBJC_USE_SUBSPECS)
 #import "ZXCodaBarWriter.h"
 #import "ZXCode39Writer.h"
 #import "ZXCode128Writer.h"
-#import "ZXDataMatrixWriter.h"
 #import "ZXEAN8Writer.h"
 #import "ZXEAN13Writer.h"
-#import "ZXErrors.h"
 #import "ZXITFWriter.h"
-#import "ZXMultiFormatWriter.h"
-#import "ZXPDF417Writer.h"
-#import "ZXQRCodeWriter.h"
 #import "ZXUPCAWriter.h"
+#endif
+#if defined(ZXINGOBJC_DATAMATRIX) || !defined(ZXINGOBJC_USE_SUBSPECS)
+#import "ZXDataMatrixWriter.h"
+#endif
+#if defined(ZXINGOBJC_PDF417) || !defined(ZXINGOBJC_USE_SUBSPECS)
+#import "ZXPDF417Writer.h"
+#endif
+#if defined(ZXINGOBJC_QRCODE) || !defined(ZXINGOBJC_USE_SUBSPECS)
+#import "ZXQRCodeWriter.h"
+#endif
 
 @implementation ZXMultiFormatWriter
 
@@ -42,6 +53,7 @@
 - (ZXBitMatrix *)encode:(NSString *)contents format:(ZXBarcodeFormat)format width:(int)width height:(int)height hints:(ZXEncodeHints *)hints error:(NSError **)error {
   id<ZXWriter> writer;
   switch (format) {
+#if defined(ZXINGOBJC_ONED) || !defined(ZXINGOBJC_USE_SUBSPECS)
     case kBarcodeFormatEan8:
       writer = [[ZXEAN8Writer alloc] init];
       break;
@@ -52,10 +64,6 @@
 
     case kBarcodeFormatUPCA:
       writer = [[ZXUPCAWriter alloc] init];
-      break;
-
-    case kBarcodeFormatQRCode:
-      writer = [[ZXQRCodeWriter alloc] init];
       break;
 
     case kBarcodeFormatCode39:
@@ -70,21 +78,34 @@
       writer = [[ZXITFWriter alloc] init];
       break;
 
+    case kBarcodeFormatCodabar:
+        writer = [[ZXCodaBarWriter alloc] init];
+        break;
+#endif
+
+#if defined(ZXINGOBJC_QRCODE) || !defined(ZXINGOBJC_USE_SUBSPECS)
+    case kBarcodeFormatQRCode:
+        writer = [[ZXQRCodeWriter alloc] init];
+        break;
+#endif
+
+#if defined(ZXINGOBJC_PDF417) || !defined(ZXINGOBJC_USE_SUBSPECS)
     case kBarcodeFormatPDF417:
       writer = [[ZXPDF417Writer alloc] init];
       break;
+#endif
 
-    case kBarcodeFormatCodabar:
-      writer = [[ZXCodaBarWriter alloc] init];
-      break;
-
+#if defined(ZXINGOBJC_DATAMATRIX) || !defined(ZXINGOBJC_USE_SUBSPECS)
     case kBarcodeFormatDataMatrix:
       writer = [[ZXDataMatrixWriter alloc] init];
       break;
+#endif
 
+#if defined(ZXINGOBJC_AZTEC) || !defined(ZXINGOBJC_USE_SUBSPECS)
     case kBarcodeFormatAztec:
       writer = [[ZXAztecWriter alloc] init];
       break;
+#endif
 
     default:
       if (error) *error = [NSError errorWithDomain:ZXErrorDomain code:ZXWriterError userInfo:@{NSLocalizedDescriptionKey: @"No encoder available for format"}];

--- a/ZXingObjC/ZXingObjC.h
+++ b/ZXingObjC/ZXingObjC.h
@@ -17,16 +17,28 @@
 #import <Foundation/Foundation.h>
 
 #ifndef _ZXINGOBJC_
-
 #define _ZXINGOBJC_
 
-#import "ZXingObjCAztec.h"
 #import "ZXingObjCCore.h"
+
+#if defined(ZXINGOBJC_AZTEC) || !defined(ZXINGOBJC_USE_SUBSPECS)
+#import "ZXingObjCAztec.h"
+#endif
+#if defined(ZXINGOBJC_DATAMATRIX) || !defined(ZXINGOBJC_USE_SUBSPECS)
 #import "ZXingObjCDataMatrix.h"
+#endif
+#if defined(ZXINGOBJC_MAXICODE) || !defined(ZXINGOBJC_USE_SUBSPECS)
 #import "ZXingObjCMaxiCode.h"
+#endif
+#if defined(ZXINGOBJC_ONED) || !defined(ZXINGOBJC_USE_SUBSPECS)
 #import "ZXingObjCOneD.h"
-#import "ZXingObjCQRCode.h"
+#endif
+#if defined(ZXINGOBJC_PDF417) || !defined(ZXINGOBJC_USE_SUBSPECS)
 #import "ZXingObjCPDF417.h"
+#endif
+#if defined(ZXINGOBJC_QRCODE) || !defined(ZXINGOBJC_USE_SUBSPECS)
+#import "ZXingObjCQRCode.h"
+#endif
 
 #import "ZXMultiFormatReader.h"
 #import "ZXMultiFormatWriter.h"


### PR DESCRIPTION
Include .h and .m files in root class folder into Core subspec
Use preprocessor definitions to compile different components
independently
This enables use of standalone subspec, current implementation only
allows use of default 'All' subspec
Improve file patterns for subspecs with use of **/* where appropriate
Add subspec for PDF417 components