### PR TITLE
Remove Core module component on QRCode

### DIFF
--- a/ZXingObjC/ZXingObjC.h
+++ b/ZXingObjC/ZXingObjC.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 #ifndef _ZXINGOBJC_
+
 #define _ZXINGOBJC_
 
 #import "ZXingObjCCore.h"

--- a/ZXingObjC/core/ZXingObjCCore.h
+++ b/ZXingObjC/core/ZXingObjCCore.h
@@ -70,8 +70,6 @@
 // Multi
 #import "ZXByQuadrantReader.h"
 #import "ZXGenericMultipleBarcodeReader.h"
-#import "ZXMultiDetector.h"
 #import "ZXMultipleBarcodeReader.h"
-#import "ZXQRCodeMultiReader.h"
 
 #endif


### PR DESCRIPTION
Hey! 
Thanks for merging #253 earlier.
This is a small follow up. I have notices that some qrcode/multi headers are included in the `core/ZXingObjCCore.h`, but actually those are not necessary and will break the build if only specific subspecs are used, not `All`.

Core component includes 2 files which are actually from qrcode/multi
Since the framework is supposed to be modular, it should be possible to
exclude QRCode module without breaking the Core component.
Also, even though the headers are imported, the qrcore/module classes
are not used anywhere in Core at all. Those are only used in multi format
reader and writer.