### PR TITLE
Hid internal file arrays by applying static declaration

### DIFF
--- a/ZXingObjC/aztec/detector/ZXAztecDetector.m
+++ b/ZXingObjC/aztec/detector/ZXAztecDetector.m
@@ -190,14 +190,14 @@
   return YES;
 }
 
-int expectedCornerBits[] = {
+static int expectedCornerBits[] = {
   0xee0,  // 07340  XXX .XX X.. ...
   0x1dc,  // 00734  ... XXX .XX X..
   0x83b,  // 04073  X.. ... XXX .XX
   0x707,  // 03407 .XX X.. ... XXX
 };
 
-int bitCount(uint32_t i) {
+static int bitCount(uint32_t i) {
   i = i - ((i >> 1) & 0x55555555);
   i = (i & 0x33333333) + ((i >> 2) & 0x33333333);
   return (((i + (i >> 4)) & 0x0F0F0F0F) * 0x01010101) >> 24;

--- a/ZXingObjC/datamatrix/decoder/ZXDataMatrixDecodedBitStreamParser.m
+++ b/ZXingObjC/datamatrix/decoder/ZXDataMatrixDecodedBitStreamParser.m
@@ -24,13 +24,13 @@
  * See ISO 16022:2006, Annex C Table C.1
  * The C40 Basic Character Set (*'s used for placeholders for the shift values)
  */
-const unichar C40_BASIC_SET_CHARS[40] = {
+static const unichar C40_BASIC_SET_CHARS[40] = {
   '*', '*', '*', ' ', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
   'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N',
   'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'
 };
 
-const unichar C40_SHIFT2_SET_CHARS[40] = {
+static const unichar C40_SHIFT2_SET_CHARS[40] = {
   '!', '"', '#', '$', '%', '&', '\'', '(', ')', '*',  '+', ',', '-', '.',
   '/', ':', ';', '<', '=', '>', '?',  '@', '[', '\\', ']', '^', '_'
 };
@@ -39,7 +39,7 @@ const unichar C40_SHIFT2_SET_CHARS[40] = {
  * See ISO 16022:2006, Annex C Table C.2
  * The Text Basic Character Set (*'s used for placeholders for the shift values)
  */
-const unichar TEXT_BASIC_SET_CHARS[40] = {
+static const unichar TEXT_BASIC_SET_CHARS[40] = {
   '*', '*', '*', ' ', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
   'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
   'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
@@ -48,7 +48,7 @@ const unichar TEXT_BASIC_SET_CHARS[40] = {
 // Shift 2 for Text is the same encoding as C40
 static unichar TEXT_SHIFT2_SET_CHARS[40];
 
-const unichar TEXT_SHIFT3_SET_CHARS[32] = {
+static const unichar TEXT_SHIFT3_SET_CHARS[32] = {
   '`', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N',
   'O',  'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '{', '|', '}', '~', (unichar) 127
 };


### PR DESCRIPTION
Static declaration is necessary for those variables when you need to use the library more then once in a project