### PR TITLE
Rotation example

### DIFF
--- a/ZXingObjC.xcodeproj/project.pbxproj
+++ b/ZXingObjC.xcodeproj/project.pbxproj
@@ -541,10 +541,10 @@
 		02DD029B1AC1C648009E4D65 /* ZXPDF417EncoderTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 02DD02991AC1C648009E4D65 /* ZXPDF417EncoderTestCase.m */; };
 		02DD029F1AC1DBAD009E4D65 /* ZXAztecDecoderTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 02DD029E1AC1DBAD009E4D65 /* ZXAztecDecoderTest.m */; };
 		02DD02A01AC1DBAD009E4D65 /* ZXAztecDecoderTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 02DD029E1AC1DBAD009E4D65 /* ZXAztecDecoderTest.m */; };
-		074684321BC3BA3C00E47A35 /* ZXGenericMultipleBarcodeReaderTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 074684311BC3BA3C00E47A35 /* ZXGenericMultipleBarcodeReaderTestCase.m */; settings = {ASSET_TAGS = (); }; };
-		074684331BC3BA3C00E47A35 /* ZXGenericMultipleBarcodeReaderTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 074684311BC3BA3C00E47A35 /* ZXGenericMultipleBarcodeReaderTestCase.m */; settings = {ASSET_TAGS = (); }; };
-		074684361BC3BC9400E47A35 /* ZXMultiAbstractBlackBoxTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 074684351BC3BC9400E47A35 /* ZXMultiAbstractBlackBoxTestCase.m */; settings = {ASSET_TAGS = (); }; };
-		074684371BC3BC9400E47A35 /* ZXMultiAbstractBlackBoxTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 074684351BC3BC9400E47A35 /* ZXMultiAbstractBlackBoxTestCase.m */; settings = {ASSET_TAGS = (); }; };
+		074684321BC3BA3C00E47A35 /* ZXGenericMultipleBarcodeReaderTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 074684311BC3BA3C00E47A35 /* ZXGenericMultipleBarcodeReaderTestCase.m */; };
+		074684331BC3BA3C00E47A35 /* ZXGenericMultipleBarcodeReaderTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 074684311BC3BA3C00E47A35 /* ZXGenericMultipleBarcodeReaderTestCase.m */; };
+		074684361BC3BC9400E47A35 /* ZXMultiAbstractBlackBoxTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 074684351BC3BC9400E47A35 /* ZXMultiAbstractBlackBoxTestCase.m */; };
+		074684371BC3BC9400E47A35 /* ZXMultiAbstractBlackBoxTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 074684351BC3BC9400E47A35 /* ZXMultiAbstractBlackBoxTestCase.m */; };
 		2504D9D016FFD2E200DF8882 /* ZXAztecCode.m in Sources */ = {isa = PBXBuildFile; fileRef = 2504D9CE16FFD2E200DF8882 /* ZXAztecCode.m */; };
 		2504D9D116FFD3A100DF8882 /* ZXAztecCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 2504D9CD16FFD2E200DF8882 /* ZXAztecCode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2504D9D316FFD3B300DF8882 /* ZXAztecCode.m in Sources */ = {isa = PBXBuildFile; fileRef = 2504D9CE16FFD2E200DF8882 /* ZXAztecCode.m */; };
@@ -6581,6 +6581,7 @@
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_VERSION = 3.1.0;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
@@ -6690,6 +6691,7 @@
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_VERSION = 3.1.0;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -6723,6 +6725,7 @@
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_VERSION = 3.1.0;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;

--- a/ZXingObjC/client/ZXCapture.m
+++ b/ZXingObjC/client/ZXCapture.m
@@ -63,7 +63,6 @@
 
     _rotation = 0.0f;
     _running = NO;
-    _sessionPreset = AVCaptureSessionPresetMedium;
     _transform = CGAffineTransformIdentity;
     _scanRect = CGRectZero;
   }
@@ -522,6 +521,11 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
 - (AVCaptureSession *)session {
   if (!_session) {
     _session = [[AVCaptureSession alloc] init];
+    if([_session canSetSessionPreset:AVCaptureSessionPreset1920x1080]){
+      _sessionPreset = AVCaptureSessionPreset1920x1080;
+    } else {
+      _sessionPreset = AVCaptureSessionPreset1280x720;
+    }
     [self replaceInput];
   }
 

--- a/examples/BarcodeScanner/BarcodeScanner-Info.plist
+++ b/examples/BarcodeScanner/BarcodeScanner-Info.plist
@@ -31,6 +31,9 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>

--- a/examples/BarcodeScanner/BarcodeScanner.xcodeproj/project.pbxproj
+++ b/examples/BarcodeScanner/BarcodeScanner.xcodeproj/project.pbxproj
@@ -418,6 +418,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "BarcodeScanner-Prefix.pch";
 				HEADER_SEARCH_PATHS = (
@@ -435,6 +436,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "BarcodeScanner-Prefix.pch";
 				HEADER_SEARCH_PATHS = (

--- a/examples/BarcodeScanner/ViewController.m
+++ b/examples/BarcodeScanner/ViewController.m
@@ -25,7 +25,9 @@
 
 @end
 
-@implementation ViewController
+@implementation ViewController {
+	CGAffineTransform _captureSizeTransform;
+}
 
 #pragma mark - View Controller Methods
 
@@ -39,9 +41,7 @@
   self.capture = [[ZXCapture alloc] init];
   self.capture.camera = self.capture.back;
   self.capture.focusMode = AVCaptureFocusModeContinuousAutoFocus;
-  self.capture.rotation = 90.0f;
 
-  self.capture.layer.frame = self.view.bounds;
   [self.view.layer addSublayer:self.capture.layer];
 
   [self.view bringSubviewToFront:self.scanRectView];
@@ -52,14 +52,90 @@
   [super viewWillAppear:animated];
 
   self.capture.delegate = self;
-  self.capture.layer.frame = self.view.bounds;
 
-  CGAffineTransform captureSizeTransform = CGAffineTransformMakeScale(320 / self.view.frame.size.width, 480 / self.view.frame.size.height);
-  self.capture.scanRect = CGRectApplyAffineTransform(self.scanRectView.frame, captureSizeTransform);
+  [self applyOrientation];
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation {
   return toInterfaceOrientation == UIInterfaceOrientationPortrait;
+}
+
+- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
+	[super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
+	[self applyOrientation];
+}
+
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id <UIViewControllerTransitionCoordinator>)coordinator {
+	[super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+	[coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+	} completion:^(id<UIViewControllerTransitionCoordinatorContext> context)
+	{
+		[self applyOrientation];
+	}];
+}
+
+#pragma mark - Private
+- (void)applyOrientation {
+	UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
+	float scanRectRotation;
+	float captureRotation;
+
+	switch (orientation) {
+		case UIInterfaceOrientationPortrait:
+			captureRotation = 0;
+			scanRectRotation = 90;
+			break;
+		case UIInterfaceOrientationLandscapeLeft:
+			captureRotation = 90;
+			scanRectRotation = 180;
+			break;
+		case UIInterfaceOrientationLandscapeRight:
+			captureRotation = 270;
+			scanRectRotation = 0;
+			break;
+		case UIInterfaceOrientationPortraitUpsideDown:
+			captureRotation = 180;
+			scanRectRotation = 270;
+			break;
+		default:
+			captureRotation = 0;
+			scanRectRotation = 90;
+			break;
+	}
+	[self applyRectOfInterest:orientation];
+	CGAffineTransform transform = CGAffineTransformMakeRotation((CGFloat) (captureRotation / 180 * M_PI));
+	[self.capture setTransform:transform];
+	[self.capture setRotation:scanRectRotation];
+	self.capture.layer.frame = self.view.frame;
+}
+
+- (void)applyRectOfInterest:(UIInterfaceOrientation)orientation {
+	CGFloat scaleVideo, scaleVideoX, scaleVideoY;
+	CGFloat videoSizeX, videoSizeY;
+	CGRect transformedVideoRect = self.scanRectView.frame;
+	videoSizeX = 360;
+	videoSizeY = 480;
+	if(UIInterfaceOrientationIsPortrait(orientation)) {
+		scaleVideoX = self.view.frame.size.width / videoSizeX;
+		scaleVideoY = self.view.frame.size.height / videoSizeY;
+		scaleVideo = MAX(scaleVideoX, scaleVideoY);
+		if(scaleVideoX > scaleVideoY) {
+			transformedVideoRect.origin.y += (scaleVideo * videoSizeY - self.view.frame.size.height) / 2;
+		} else {
+			transformedVideoRect.origin.x += (scaleVideo * videoSizeX - self.view.frame.size.width) / 2;
+		}
+	} else {
+		scaleVideoX = self.view.frame.size.width / videoSizeY;
+		scaleVideoY = self.view.frame.size.height / videoSizeX;
+		scaleVideo = MAX(scaleVideoX, scaleVideoY);
+		if(scaleVideoX > scaleVideoY) {
+			transformedVideoRect.origin.y += (scaleVideo * videoSizeX - self.view.frame.size.height) / 2;
+		} else {
+			transformedVideoRect.origin.x += (scaleVideo * videoSizeY - self.view.frame.size.width) / 2;
+		}
+	}
+	_captureSizeTransform = CGAffineTransformMakeScale(1/scaleVideo, 1/scaleVideo);
+	self.capture.scanRect = CGRectApplyAffineTransform(transformedVideoRect, _captureSizeTransform);
 }
 
 #pragma mark - Private Methods
@@ -124,9 +200,22 @@
 - (void)captureResult:(ZXCapture *)capture result:(ZXResult *)result {
   if (!result) return;
 
+	CGAffineTransform inverse = CGAffineTransformInvert(_captureSizeTransform);
+	NSMutableArray *points = [[NSMutableArray alloc] init];
+	NSString *location = @"";
+	for (ZXResultPoint *resultPoint in result.resultPoints) {
+		CGPoint cgPoint = CGPointMake(resultPoint.x, resultPoint.y);
+		CGPoint transformedPoint = CGPointApplyAffineTransform(cgPoint, inverse);
+		transformedPoint = [self.scanRectView convertPoint:transformedPoint toView:self.scanRectView.window];
+		NSValue* windowPointValue = [NSValue valueWithCGPoint:transformedPoint];
+		location = [NSString stringWithFormat:@"%@ (%f, %f)", location, transformedPoint.x, transformedPoint.y];
+		[points addObject:windowPointValue];
+	}
+
+
   // We got a result. Display information about the result onscreen.
   NSString *formatString = [self barcodeFormatToString:result.barcodeFormat];
-  NSString *display = [NSString stringWithFormat:@"Scanned!\n\nFormat: %@\n\nContents:\n%@", formatString, result.text];
+  NSString *display = [NSString stringWithFormat:@"Scanned!\n\nFormat: %@\n\nContents:\n%@\nLocation: %@", formatString, result.text, location];
   [self.decodedLabel performSelectorOnMainThread:@selector(setText:) withObject:display waitUntilDone:YES];
 
   // Vibrate

--- a/examples/BarcodeScanner/ViewController.m
+++ b/examples/BarcodeScanner/ViewController.m
@@ -113,8 +113,13 @@
 	CGFloat scaleVideo, scaleVideoX, scaleVideoY;
 	CGFloat videoSizeX, videoSizeY;
 	CGRect transformedVideoRect = self.scanRectView.frame;
-	videoSizeX = 360;
-	videoSizeY = 480;
+	if([self.capture.sessionPreset isEqualToString:AVCaptureSessionPreset1920x1080]) {
+		videoSizeX = 1080;
+		videoSizeY = 1920;
+	} else {
+		videoSizeX = 720;
+		videoSizeY = 1280;
+	}
 	if(UIInterfaceOrientationIsPortrait(orientation)) {
 		scaleVideoX = self.view.frame.size.width / videoSizeX;
 		scaleVideoY = self.view.frame.size.height / videoSizeY;


### PR DESCRIPTION
Hi,
I've added in the example for iOS how the screen is rotated plus the location of the barcode is shown. In addition, I made a separate commit where I changed the resolution to a higher value. Actually, I don't know why the resolution is set to medium and not to something higher because 1920x1080 is supported on almost every device nowadays and there were no performance issues on my devices. 