### PR TITLE
Increase quiet zone (margin) for 1D barcodes

### DIFF
--- a/ZXingObjC/oned/ZXOneDimensionalCodeWriter.m
+++ b/ZXingObjC/oned/ZXOneDimensionalCodeWriter.m
@@ -45,7 +45,7 @@
   }
 
   int sidesMargin = [self defaultMargin];
-  if (hints && hints.margin) {
+  if (hints && hints.margin && hints.margin.intValue >= sidesMargin) {
     sidesMargin = hints.margin.intValue;
   }
 
@@ -59,11 +59,12 @@
 - (ZXBitMatrix *)renderResult:(ZXBoolArray *)code width:(int)width height:(int)height sidesMargin:(int)sidesMargin {
   int inputWidth = code.length;
   // Add quiet zone on both sides.
-  int fullWidth = inputWidth + sidesMargin;
+  int fullWidth = inputWidth + sidesMargin * 2;
   int outputWidth = MAX(width, fullWidth);
   int outputHeight = MAX(1, height);
 
   int multiple = outputWidth / fullWidth;
+  outputWidth = fullWidth * multiple;
   int leftPadding = (outputWidth - (inputWidth * multiple)) / 2;
 
   ZXBitMatrix *output = [[ZXBitMatrix alloc] initWithWidth:outputWidth height:outputHeight];


### PR DESCRIPTION
**Issue:**
When generated code128 barcode images are displayed on a dark background, POS scanners cannot scan due to insufficient quiet zone.

**Reason:**
defaultMarigin in ZXOneDimensionalCodeWriter is set to 10x, which is split between left and right quiet zones. So, the quiet zone width is reduced which makes it hard for physical barcode scanners.

**Fix:**
Double the defaultMargin value. So, the quiet zones are properly included within the generated image instead of requiring the app to add padding around the image.

**Before:**
![before](https://cloud.githubusercontent.com/assets/570612/18235472/4600c01e-72e9-11e6-97fd-0c79d733b654.png)

**After:**
![after](https://cloud.githubusercontent.com/assets/570612/18235474/512f30ba-72e9-11e6-8d20-2a34698e7981.png)
