### PR TITLE
Add Product Bundle Identifier to OS X Framework target

### DIFF
--- a/ZXingObjC.xcodeproj/project.pbxproj
+++ b/ZXingObjC.xcodeproj/project.pbxproj
@@ -6701,6 +6701,7 @@
 				INFOPLIST_FILE = "mac-Info.plist";
 				LD_DYLIB_INSTALL_NAME = "@rpath/../Frameworks/$(EXECUTABLE_PATH)";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.zxing.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = ZXingObjC;
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = framework;
@@ -6907,6 +6908,7 @@
 				INFOPLIST_FILE = "mac-Info.plist";
 				LD_DYLIB_INSTALL_NAME = "@rpath/../Frameworks/$(EXECUTABLE_PATH)";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.zxing.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = ZXingObjC;
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = framework;
@@ -6931,6 +6933,7 @@
 				INFOPLIST_FILE = "mac-Info.plist";
 				LD_DYLIB_INSTALL_NAME = "@rpath/../Frameworks/$(EXECUTABLE_PATH)";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.zxing.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = ZXingObjC;
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = framework;


### PR DESCRIPTION
Sorry about omitting this in my last PR - discovered this while submitting my app to the Mac App Store.

Whilst the Info.plist for the Mac framework contained the bundle identifier key, the value (`$(PRODUCT_BUNDLE_IDENTIFIER)`) wasn't actually set in the `project.pbxproj` file (as it was for the iOS framework).

This update sets the bundle identifier for the Mac framework target and resolves another potential codesigning issue.

Thanks again! 🎉 