### PR TITLE
clarify carthage preference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ github "TheLevelUp/ZXingObjC" ~> 3.2.1
 
 #### CocoaPods
 
-The recommended way to install ZXingObjC is with [CocoaPods](http://cocoapods.org), a dependency mananger for Objective-C projects. After installing CocoaPods just add ZXingObjC to your Podfile:
+[CocoaPods](http://cocoapods.org) is a dependency manager for Swift and Objective-C Cocoa projects. After installing CocoaPods add ZXingObjC to your Podfile:
 
 ```ruby
 platform :ios, '7.0'


### PR DESCRIPTION
As of https://github.com/TheLevelUp/ZXingObjC/commit/9420f9809a36e96be3a841229e167398be675ce1 the README recommends Carthage over Cocoapods, so to be consistent we should no longer say Cocoapods is the preferred installation method.