### PR TITLE
Fix app crashing when running on device without torch

### DIFF
--- a/ZXingObjC/client/ZXCapture.m
+++ b/ZXingObjC/client/ZXCapture.m
@@ -177,7 +177,12 @@
   _torch = torch;
 
   [self.input.device lockForConfiguration:nil];
-  self.input.device.torchMode = self.torch ? AVCaptureTorchModeOn : AVCaptureTorchModeOff;
+  
+  AVCaptureTorchMode torchMode = self.torch ? AVCaptureTorchModeOn : AVCaptureTorchModeOff;
+  if ([self.input.device isTorchModeSupported:torchMode]) {
+    self.input.device.torchMode = torchMode;
+  }
+  
   [self.input.device unlockForConfiguration];
 }
 


### PR DESCRIPTION
I encountered this error when trying to use ZXingObjC on iPad. My app crashed with error message suggesting that I should chech for isTorchModeSupported before setting the mode.