### PR TITLE
ZXImage crash #380

### DIFF
--- a/ZXingObjC/client/ZXImage.m
+++ b/ZXingObjC/client/ZXImage.m
@@ -83,53 +83,53 @@
 }
 
 + (ZXImage *)imageWithMatrix:(ZXBitMatrix *)matrix onColor:(CGColorRef)onColor offColor:(CGColorRef)offColor {
-  int8_t onIntensities[4], offIntensities[4];
-
-  [self setColorIntensities:onIntensities color:onColor];
-  [self setColorIntensities:offIntensities color:offColor];
-
-  int width = matrix.width;
-  int height = matrix.height;
-  int8_t *bytes = (int8_t *)malloc(width * height * 4);
-  for (int y = 0; y < height; y++) {
-    for (int x = 0; x < width; x++) {
-      BOOL bit = [matrix getX:x y:y];
-      for (int i = 0; i < 4; i++) {
-        int8_t intensity = bit ? onIntensities[i] : offIntensities[i];
-        bytes[y * width * 4 + x * 4 + i] = intensity;
-      }
+    uint8_t onIntensities[4], offIntensities[4];
+    
+    [self setColorIntensities:onIntensities color:onColor];
+    [self setColorIntensities:offIntensities color:offColor];
+    
+    int width = matrix.width;
+    int height = matrix.height;
+    int8_t *bytes = (int8_t *)malloc(width * height * 4);
+    for (int y = 0; y < height; y++) {
+        for (int x = 0; x < width; x++) {
+            BOOL bit = [matrix getX:x y:y];
+            for (int i = 0; i < 4; i++) {
+                int8_t intensity = bit ? onIntensities[i] : offIntensities[i];
+                bytes[y * width * 4 + x * 4 + i] = intensity;
+            }
+        }
     }
-  }
-
-  CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-  CGContextRef c = CGBitmapContextCreate(bytes, width, height, 8, 4 * width, colorSpace, kCGBitmapAlphaInfoMask & kCGImageAlphaPremultipliedLast);
-  CFRelease(colorSpace);
-  CGImageRef image = CGBitmapContextCreateImage(c);
-  CFRelease(c);
-  free(bytes);
-
-  ZXImage *zxImage = [[ZXImage alloc] initWithCGImageRef:image];
-
-  CFRelease(image);
-  return zxImage;
+    
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    CGContextRef c = CGBitmapContextCreate(bytes, width, height, 8, 4 * width, colorSpace, kCGBitmapAlphaInfoMask & kCGImageAlphaPremultipliedLast);
+    CFRelease(colorSpace);
+    CGImageRef image = CGBitmapContextCreateImage(c);
+    CFRelease(c);
+    free(bytes);
+    
+    ZXImage *zxImage = [[ZXImage alloc] initWithCGImageRef:image];
+    
+    CFRelease(image);
+    return zxImage;
 }
 
-+ (void)setColorIntensities:(int8_t *)intensities color:(CGColorRef)color {
-  memset(intensities, 0, 4);
-
-  size_t numberOfComponents = CGColorGetNumberOfComponents(color);
-  const CGFloat *components = CGColorGetComponents(color);
-
-  if (numberOfComponents == 4) {
-    for (int i = 0; i < 4; i++) {
-      intensities[i] = components[i] * 255;
++ (void)setColorIntensities:(uint8_t *)intensities color:(CGColorRef)color {
+    memset(intensities, 0, 4);
+    
+    size_t numberOfComponents = CGColorGetNumberOfComponents(color);
+    const CGFloat *components = CGColorGetComponents(color);
+    
+    if (numberOfComponents == 4) {
+        for (int i = 0; i < 4; i++) {
+            intensities[i] = MIN(1.0, MAX(0, components[i])) * 255;
+        }
+    } else if (numberOfComponents == 2) {
+        for (int i = 0; i < 3; i++) {
+            intensities[i] = MIN(1.0, MAX(0, components[0])) * 255;
+        }
+        intensities[3] = MIN(1.0, MAX(0, components[1])) * 255;
     }
-  } else if (numberOfComponents == 2) {
-    for (int i = 0; i < 3; i++) {
-      intensities[i] = components[0] * 255;
-    }
-    intensities[3] = components[1] * 255;
-  }
 }
 
 @end


### PR DESCRIPTION
Fixes #380

Recent changes appear to trigger overflow protection code that crashes on latest iOS + devices. Doesn't occur on debug builds, only release. The issue is that components for setting color intensities are declared as int8_t (signed) when they shouldn't be. See linked issue for more explanation, but the fix is to a) declare proper storage type and b) clamp component values to [0.0, 1.0].