### PR TITLE
Restore data sign substitution functionality

### DIFF
--- a/ZXingObjC/core/ZXDecodeHints.h
+++ b/ZXingObjC/core/ZXDecodeHints.h
@@ -89,6 +89,9 @@
 /**
  * Image is known to be of one of a few possible formats.
  */
+
+@property (nonatomic, strong) NSDictionary *substitutions;
+
 - (void)addPossibleFormat:(ZXBarcodeFormat)format;
 - (BOOL)containsFormat:(ZXBarcodeFormat)format;
 - (int)numberOfPossibleFormats;

--- a/ZXingObjC/core/ZXDecodeHints.m
+++ b/ZXingObjC/core/ZXDecodeHints.m
@@ -59,11 +59,11 @@
 }
 
 - (void)addPossibleFormat:(ZXBarcodeFormat)format {
-  [self.barcodeFormats addObject:[NSNumber numberWithInt:format]];
+  [self.barcodeFormats addObject:@(format)];
 }
 
 - (BOOL)containsFormat:(ZXBarcodeFormat)format {
-  return [self.barcodeFormats containsObject:[NSNumber numberWithInt:format]];
+  return [self.barcodeFormats containsObject:@(format)];
 }
 
 - (int)numberOfPossibleFormats {
@@ -71,7 +71,7 @@
 }
 
 - (void)removePossibleFormat:(ZXBarcodeFormat)format {
-  [self.barcodeFormats removeObject:[NSNumber numberWithInt:format]];
+  [self.barcodeFormats removeObject:@(format)];
 }
 
 @end

--- a/ZXingObjC/oned/ZXCode128Reader.m
+++ b/ZXingObjC/oned/ZXCode128Reader.m
@@ -286,13 +286,11 @@ const int ZX_CODE128_CODE_STOP = 106;
 
     [rawCodes addObject:@(code)];
 
-    // Remember whether the last code was printable or not (excluding ZX_CODE128_CODE_STOP)
+    // Remember whether the last code was printable or not
+    // and Add to checksum computation
+    // (excluding ZX_CODE128_CODE_STOP)
     if (code != ZX_CODE128_CODE_STOP) {
       lastCharacterWasPrintable = YES;
-    }
-
-    // Add to checksum computation (if not ZX_CODE128_CODE_STOP of course)
-    if (code != ZX_CODE128_CODE_STOP) {
       multiplier++;
       checksumTotal += multiplier * code;
     }
@@ -310,13 +308,23 @@ const int ZX_CODE128_CODE_STOP = 106;
       return nil;
     }
 
+    bool wasAlreadyAppended = NO;
+    if(hints.substitutions != nil && hints.substitutions.count > 0) {
+        NSString *signCandidate = [hints.substitutions valueForKey:[NSString stringWithFormat:@"%d", code]];
+        if (signCandidate != nil) {
+            // Substitute
+            [result appendString:signCandidate];
+            wasAlreadyAppended = YES;
+        }
+    }
+
     switch (codeSet) {
     case ZX_CODE128_CODE_CODE_A:
       if (code < 64) {
         if (shiftUpperMode == upperMode) {
-          [result appendFormat:@"%C", (unichar)(' ' + code)];
+          if(!wasAlreadyAppended) [result appendFormat:@"%C", (unichar)(' ' + code)];
         } else {
-          [result appendFormat:@"%C", (unichar)(' ' + code + 128)];
+          if(!wasAlreadyAppended) [result appendFormat:@"%C", (unichar)(' ' + code + 128)];
         }
         shiftUpperMode = NO;
       } else if (code < 96) {
@@ -380,9 +388,9 @@ const int ZX_CODE128_CODE_STOP = 106;
     case ZX_CODE128_CODE_CODE_B:
       if (code < 96) {
         if (shiftUpperMode == upperMode) {
-          [result appendFormat:@"%C", (unichar)(' ' + code)];
+          if(!wasAlreadyAppended) [result appendFormat:@"%C", (unichar)(' ' + code)];
         } else {
-          [result appendFormat:@"%C", (unichar)(' ' + code + 128)];
+          if(!wasAlreadyAppended) [result appendFormat:@"%C", (unichar)(' ' + code + 128)];
         }
         shiftUpperMode = NO;
       } else {
@@ -436,10 +444,12 @@ const int ZX_CODE128_CODE_STOP = 106;
       break;
     case ZX_CODE128_CODE_CODE_C:
       if (code < 100) {
-        if (code < 10) {
-          [result appendString:@"0"];
+        if(!wasAlreadyAppended) {
+          if (code < 10) {
+            [result appendString:@"0"];
+          }
+          [result appendFormat:@"%d", code];
         }
-        [result appendFormat:@"%d", code];
       } else {
         if (code != ZX_CODE128_CODE_STOP) {
           lastCharacterWasPrintable = NO;

--- a/ZXingObjC/oned/ZXCode128Reader.m
+++ b/ZXingObjC/oned/ZXCode128Reader.m
@@ -236,7 +236,7 @@ const int ZX_CODE128_CODE_STOP = 106;
   int startCode = startPatternInfo.array[2];
   int codeSet;
 
-  NSMutableArray *rawCodes = [NSMutableArray arrayWithObject:@(startCode)];
+  NSMutableArray *rawCodes = [@[@(startCode)] mutableCopy];
 
   switch (startCode) {
   case ZX_CODE128_CODE_START_A:
@@ -480,6 +480,9 @@ const int ZX_CODE128_CODE_STOP = 106;
         }
       }
       break;
+
+      default:
+        break;
     }
 
     // Unshift back to another code set if we were shifted

--- a/ZXingObjC/oned/ZXOneDReader.m
+++ b/ZXingObjC/oned/ZXOneDReader.m
@@ -185,10 +185,8 @@
     i++;
   }
 
-  if (!(counterPosition == numCounters || (counterPosition == numCounters - 1 && i == end))) {
-    return NO;
-  }
-  return YES;
+  return counterPosition == numCounters ||
+          (counterPosition == numCounters - 1 && i == end);
 }
 
 + (BOOL)recordPatternInReverse:(ZXBitArray *)row start:(int)start counters:(ZXIntArray *)counters {
@@ -201,10 +199,7 @@
     }
   }
 
-  if (numTransitionsLeft >= 0 || ![self recordPattern:row start:start + 1 counters:counters]) {
-    return NO;
-  }
-  return YES;
+  return !(numTransitionsLeft >= 0 || ![self recordPattern:row start:start + 1 counters:counters]);
 }
 
 /**


### PR DESCRIPTION
At some point in history, this functionality has been deleted and I don't know, why. It is useful in some cases, however.
Additionally, I did some refactoring in connected areas.