### PR TITLE
Added CGImageRelease call in encoding example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ if (result) {
   CGImageRef image = CGImageRetain([[ZXImage imageWithMatrix:result] cgimage]);
 
   // This CGImageRef image can be placed in a UIImage, NSImage, or written to a file.
+  
+  CGImageRelease(image);
 } else {
   NSString *errorMessage = [error localizedDescription];
 }


### PR DESCRIPTION
Added CGImageRelease call following CGImageRetain call in the encoding usage example to demonstrate good practice of lowering the reference count of an object after use.