### PR TITLE
Fixed multibyte charset problem when encoding PDF417 with AUTO

### DIFF
--- a/ZXingObjC/pdf417/encoder/ZXPDF417HighLevelEncoder.m
+++ b/ZXingObjC/pdf417/encoder/ZXPDF417HighLevelEncoder.m
@@ -195,7 +195,7 @@ const NSStringEncoding ZX_PDF417_DEFAULT_ENCODING = NSISOLatin1StringEncoding;
           } else if (b == 0) {
             b = 1;
           }
-          NSString *submsg = [msg substringWithRange:NSMakeRange(p, p + b)];
+          NSString *submsg = [msg substringWithRange:NSMakeRange(p, b)];
           ZXByteArray *bytes = [self bytesForMessage:submsg encoding:encoding];
           if (bytes.length ==1 && encodingMode == ZX_PDF417_TEXT_COMPACTION) {
             //Switch for one byte (instead of latch)

--- a/ZXingObjC/pdf417/encoder/ZXPDF417HighLevelEncoder.m
+++ b/ZXingObjC/pdf417/encoder/ZXPDF417HighLevelEncoder.m
@@ -195,7 +195,7 @@ const NSStringEncoding ZX_PDF417_DEFAULT_ENCODING = NSISOLatin1StringEncoding;
           } else if (b == 0) {
             b = 1;
           }
-          NSString *submsg = [msg substringWithRange:NSMakeRange(p, b)];
+          NSString *submsg = [msg substringWithRange:NSMakeRange(p, p + b)];
           ZXByteArray *bytes = [self bytesForMessage:submsg encoding:encoding];
           if (bytes.length ==1 && encodingMode == ZX_PDF417_TEXT_COMPACTION) {
             //Switch for one byte (instead of latch)

--- a/ZXingObjCTests/pdf417/encoder/ZXPDF417EncoderTestCase.m
+++ b/ZXingObjCTests/pdf417/encoder/ZXPDF417EncoderTestCase.m
@@ -55,4 +55,11 @@
   XCTAssertEqualObjects(expected, encoded);
 }
 
+- (void)testEncodeAutoWithSpecialChars {
+  // just check if this does not throw an error
+  NSError *error;
+  [ZXPDF417HighLevelEncoder encodeHighLevel:@"1%§s ?aG$" compaction:ZXPDF417CompactionAuto encoding:NSUTF8StringEncoding error:&error];
+  XCTAssertNil(error);
+}
+
 @end

--- a/ZXingObjCTests/pdf417/encoder/ZXPDF417EncoderTestCase.m
+++ b/ZXingObjCTests/pdf417/encoder/ZXPDF417EncoderTestCase.m
@@ -62,4 +62,11 @@
   XCTAssertNil(error);
 }
 
+- (void)testEncodeIso88591WithSpecialChars {
+  // just check if this does not throw an error
+  NSError *error;
+  [ZXPDF417HighLevelEncoder encodeHighLevel:@"asdfg§asd" compaction:ZXPDF417CompactionAuto encoding:NSISOLatin1StringEncoding error:&error];
+  XCTAssertNil(error);
+}
+
 @end


### PR DESCRIPTION
Ported 060010253c46d8c9d8c54a0aff854e11cdf59f1b
Ported 849f81354c5f73abfde98a12804bdb909f6a9ba8