### PR TITLE
Fix UPCE checksum calculation

### DIFF
--- a/ZXingObjC.xcodeproj/project.pbxproj
+++ b/ZXingObjC.xcodeproj/project.pbxproj
@@ -1671,7 +1671,6 @@
 		4B2058252155B4F1009146DB /* ZXRGBLuminanceSourceTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B20581C2155B19C009146DB /* ZXRGBLuminanceSourceTestCase.m */; };
 		4B2058262155B4F1009146DB /* ZXRGBLuminanceSourceTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B20581C2155B19C009146DB /* ZXRGBLuminanceSourceTestCase.m */; };
 		4B42B89F215904EB0010C328 /* ZXUPCEWriterTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B42B89E215904EB0010C328 /* ZXUPCEWriterTestCase.m */; };
-		4B42B8A0215904EB0010C328 /* ZXUPCEWriterTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B42B89E215904EB0010C328 /* ZXUPCEWriterTestCase.m */; };
 		4B42B8A421590C920010C328 /* ZXITFWriterTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B42B8A321590C920010C328 /* ZXITFWriterTestCase.m */; };
 		4B42B8A521590C920010C328 /* ZXITFWriterTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B42B8A321590C920010C328 /* ZXITFWriterTestCase.m */; };
 		4B42B8A7215917A40010C328 /* ZXCode39ExtendedModeTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B42B8A6215917A40010C328 /* ZXCode39ExtendedModeTestCase.m */; };
@@ -6166,7 +6165,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4B42B8A0215904EB0010C328 /* ZXUPCEWriterTestCase.m in Sources */,
 				023E69A118C0EF55001FF123 /* ZXAztecBlackBox1TestCase.m in Sources */,
 				023E69A218C0EF55001FF123 /* ZXAztecBlackBox2TestCase.m in Sources */,
 				023E69A318C0EF55001FF123 /* ZXAbstractBlackBoxTestCase.m in Sources */,

--- a/ZXingObjC/oned/ZXUPCEReader.m
+++ b/ZXingObjC/oned/ZXUPCEReader.m
@@ -114,8 +114,8 @@ const int ZX_UCPE_NUMSYS_AND_CHECK_DIGIT_PATTERNS[][10] = {
                                     error:error];
 }
 
-- (BOOL)checkChecksum:(NSString *)s error:(NSError **)error {
-  return [super checkChecksum:[ZXUPCEReader convertUPCEtoUPCA:s] error:error];
++ (BOOL)checkStandardUPCEANChecksum:(NSString *)s {
+    return [super checkStandardUPCEANChecksum:[ZXUPCEReader convertUPCEtoUPCA:s]];
 }
 
 - (BOOL)determineNumSysAndCheckDigit:(NSMutableString *)resultString lgPatternFound:(int)lgPatternFound {

--- a/ZXingObjC/oned/ZXUPCEWriter.m
+++ b/ZXingObjC/oned/ZXUPCEWriter.m
@@ -41,7 +41,7 @@ const int ZX_UPCE_CODE_WIDTH = 3 + (7 * 6) + 6;
       contents = [contents stringByAppendingString:[NSString stringWithFormat:@"%d", [ZXUPCEANReader standardUPCEANChecksum:[ZXUPCEReader convertUPCEtoUPCA:contents]]]];
       break;
     case 8:
-      if (![ZXUPCEANReader checkStandardUPCEANChecksum:contents]) {
+      if (![ZXUPCEReader checkStandardUPCEANChecksum:contents]) {
         @throw [NSException exceptionWithName:@"IllegalArgumentException"
                                        reason:@"Contents do not pass checksum"
                                      userInfo:nil];

--- a/ZXingObjCTests/oned/ZXUPCEWriterTestCase.m
+++ b/ZXingObjCTests/oned/ZXUPCEWriterTestCase.m
@@ -42,6 +42,18 @@
   }
 }
 
+- (void)testAddChecksumAndEncodeWithChecksum {
+    NSString *testStr = @"0000000000010100111010001101001110101011110001101010011101010100000000000";
+    ZXBitMatrix *result = [[[ZXUPCEWriter alloc] init] encode:@"04046008"
+                                                       format:kBarcodeFormatUPCE
+                                                        width:(int)testStr.length
+                                                       height:0
+                                                        error:nil];
+    for (int i = 0; i < testStr.length; i++) {
+        XCTAssertEqual([result getX:i y:0], [testStr characterAtIndex:i] == '1', @"Element %d", i);
+    }
+}
+
 - (void)testEncodeIllegalCharacters {
   XCTAssertThrows([[[ZXUPCEWriter alloc] init] encode:@"05096abc"
                                                 format:kBarcodeFormatUPCE


### PR DESCRIPTION
Encoding `04046008` was throwing an exception when encoding. However, that is a valid UPCE code according to https://www.upcdatabase.com/checkdigit.asp.

I also added a test that should catch eventual regressions.

